### PR TITLE
Use async free when free_all

### DIFF
--- a/bminf/core/allocators/cuda.py
+++ b/bminf/core/allocators/cuda.py
@@ -39,9 +39,13 @@ class CUDAAllocator(Allocator):
     
     def free_all(self):
         with self.device:
-            for mem in self.__allocated:
-                cudart.cudaFreeAsync(mem.ptr, cudart.cudaStreamNonBlocking)
-            cudart.cudaStreamSynchronize(cudart.cudaStreamNonBlocking)
+            if cudart.MALLOC_AYNC_SUPPORT:
+                for mem in self.__allocated:
+                    cudart.cudaFreeAsync(mem.ptr, cudart.cudaStreamNonBlocking)
+                cudart.cudaStreamSynchronize(cudart.cudaStreamNonBlocking)
+            else:
+                for mem in self.__allocated:
+                    cudart.cudaFree(mem.ptr)
 
     def __del__(self):
         try:

--- a/bminf/core/allocators/cuda.py
+++ b/bminf/core/allocators/cuda.py
@@ -40,7 +40,8 @@ class CUDAAllocator(Allocator):
     def free_all(self):
         with self.device:
             for mem in self.__allocated:
-                cudart.cudaFree(mem.ptr)
+                cudart.cudaFreeAsync(mem.ptr, cudart.cudaStreamNonBlocking)
+            cudart.cudaStreamSynchronize(cudart.cudaStreamNonBlocking)
 
     def __del__(self):
         try:


### PR DESCRIPTION
There are n gpu memory that need to be free
If using synchronous free, e2e time = n*(gpu free time + cpu callback time)
If using asynchronous free, e2e time = n*(gpu free time) + 1* cpu callback time

Like cudagraph, can save cpu time